### PR TITLE
Update code and dependencies to support a minimum of Node 6

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,18 +1,18 @@
 #!/usr/bin/env node
 
-var spawn = require('cross-spawn')
-var npmRunPath = require('npm-run-path-compat')
-var log = require('npmlog')
-var versionChanged = require('version-changed')
-var version = require('./package').version
-var getTarget = require('node-abi').getTarget
+const spawn = require('cross-spawn')
+const npmRunPath = require('npm-run-path-compat')
+const log = require('npmlog')
+const versionChanged = require('version-changed')
+const version = require('./package').version
+const getTarget = require('node-abi').getTarget
 
 if (!process.env.CI) process.exit()
 
 log.heading = 'prebuild-ci'
 log.level = 'verbose'
 
-var token = process.env.PREBUILD_TOKEN
+const token = process.env.PREBUILD_TOKEN
 if (!token) {
   log.error('PREBUILD_TOKEN required')
   process.exit(0)
@@ -20,7 +20,7 @@ if (!token) {
 
 function prebuild (runtime, target, cb) {
   log.info('build', runtime, 'abi', target)
-  var ps = spawn('prebuild', [
+  const ps = spawn('prebuild', [
     '-r', runtime,
     '-t', target,
     '-u', token,

--- a/package.json
+++ b/package.json
@@ -8,14 +8,17 @@
     "prebuild-ci": "./index.js"
   },
   "dependencies": {
-    "cross-spawn": "^5.0.1",
-    "node-abi": "^2.0.0",
+    "cross-spawn": "^6.0.5",
+    "node-abi": "^2.7.1",
     "npm-run-path-compat": "^2.0.3",
-    "npmlog": "^4.0.2",
+    "npmlog": "^4.1.2",
     "version-changed": "^1.1.1"
   },
   "devDependencies": {
-    "standard": "^8.6.0"
+    "standard": "^12.0.1"
+  },
+  "engines": {
+    "node": ">=6"
   },
   "scripts": {
     "test": "standard"


### PR DESCRIPTION
Hello, I've got some potential improvements lined to up help this module with the increasingly-oddball Electron ABI versioning but if it's OK I'd first like to update the internals to require Node 6+, which this PR attempts to achieve.

The `cross-spawn` major update is due to it dropping support for Node <4.