### PR TITLE
Build list of ABI targets dynamically

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 node_modules
 package-lock.json
+test

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,2 @@
-node_modules
 package-lock.json
 test

--- a/build-targets.js
+++ b/build-targets.js
@@ -1,0 +1,39 @@
+function buildTargets (currentNodeAbi, supportedTargets) {
+  const nodeAbis = supportedTargets
+    .filter(target => target.runtime === 'node')
+    .map(target => target.abi)
+
+  const electronAbis = supportedTargets
+    .filter(target => target.runtime === 'electron')
+    .map(target => target.abi)
+
+  const oddballElectronAbis = electronAbis.filter(
+    electronAbi =>
+      electronAbi >= currentNodeAbi && !nodeAbis.includes(electronAbi)
+  )
+
+  // Current Node ABI
+  const targets = [
+    {
+      runtime: 'node',
+      abi: currentNodeAbi
+    }
+  ]
+  // Electron with same ABI as current Node
+  if (electronAbis.includes(currentNodeAbi)) {
+    targets.push({
+      runtime: 'electron',
+      abi: currentNodeAbi
+    })
+  }
+  // Oddball Electron ABIs
+  oddballElectronAbis.forEach(oddballAbi => {
+    targets.push({
+      runtime: 'electron',
+      abi: oddballAbi
+    })
+  })
+  return targets
+}
+
+module.exports = buildTargets

--- a/package.json
+++ b/package.json
@@ -12,15 +12,17 @@
     "node-abi": "^2.7.1",
     "npm-run-path-compat": "^2.0.3",
     "npmlog": "^4.1.2",
+    "run-series": "^1.1.8",
     "version-changed": "^1.1.1"
   },
   "devDependencies": {
-    "standard": "^12.0.1"
+    "standard": "^12.0.1",
+    "tape": "^4.10.1"
   },
   "engines": {
     "node": ">=6"
   },
   "scripts": {
-    "test": "standard"
+    "test": "standard && tape test/*-test.js"
   }
 }

--- a/test/build-targets-test.js
+++ b/test/build-targets-test.js
@@ -1,0 +1,68 @@
+const test = require('tape')
+
+const buildTargets = require('../build-targets')
+
+const supportedTargets = [
+  { runtime: 'node', target: '5.0.0', abi: '47', lts: false },
+  { runtime: 'node', target: '6.0.0', abi: '48', lts: false },
+  { runtime: 'node', target: '7.0.0', abi: '51', lts: false },
+  { runtime: 'node', target: '8.0.0', abi: '57', lts: true },
+  { runtime: 'node', target: '9.0.0', abi: '59', lts: false },
+  { runtime: 'node', target: '10.0.0', abi: '64', lts: true },
+  { runtime: 'node', target: '11.0.0', abi: '67', lts: false },
+  { runtime: 'electron', target: '0.36.0', abi: '47', lts: false },
+  { runtime: 'electron', target: '1.1.0', abi: '48', lts: false },
+  { runtime: 'electron', target: '1.3.0', abi: '49', lts: false },
+  { runtime: 'electron', target: '1.4.0', abi: '50', lts: false },
+  { runtime: 'electron', target: '1.5.0', abi: '51', lts: false },
+  { runtime: 'electron', target: '1.6.0', abi: '53', lts: false },
+  { runtime: 'electron', target: '1.7.0', abi: '54', lts: false },
+  { runtime: 'electron', target: '1.8.0', abi: '57', lts: false },
+  { runtime: 'electron', target: '2.0.0', abi: '57', lts: false },
+  { runtime: 'electron', target: '3.0.0', abi: '64', lts: false },
+  { runtime: 'electron', target: '4.0.0', abi: '64', lts: false },
+  { runtime: 'electron', target: '4.0.4', abi: '69', lts: false }
+]
+
+test('build targets using Node 6 (ABI 48)', function (t) {
+  t.plan(1)
+  const targets = buildTargets('48', supportedTargets)
+  t.deepEqual(targets, [
+    { runtime: 'node', abi: '48' },
+    { runtime: 'electron', abi: '48' },
+    { runtime: 'electron', abi: '49' },
+    { runtime: 'electron', abi: '50' },
+    { runtime: 'electron', abi: '53' },
+    { runtime: 'electron', abi: '54' },
+    { runtime: 'electron', abi: '69' }
+  ])
+})
+
+test('build targets using Node 8 (ABI 57)', function (t) {
+  t.plan(1)
+  const targets = buildTargets('57', supportedTargets)
+  t.deepEqual(targets, [
+    { runtime: 'node', abi: '57' },
+    { runtime: 'electron', abi: '57' },
+    { runtime: 'electron', abi: '69' }
+  ])
+})
+
+test('build targets using Node 10 (ABI 64)', function (t) {
+  t.plan(1)
+  const targets = buildTargets('64', supportedTargets)
+  t.deepEqual(targets, [
+    { runtime: 'node', abi: '64' },
+    { runtime: 'electron', abi: '64' },
+    { runtime: 'electron', abi: '69' }
+  ])
+})
+
+test('build targets using Node 11 (ABI 67)', function (t) {
+  t.plan(1)
+  const targets = buildTargets('67', supportedTargets)
+  t.deepEqual(targets, [
+    { runtime: 'node', abi: '67' },
+    { runtime: 'electron', abi: '69' }
+  ])
+})


### PR DESCRIPTION
Hello, this proposed PR changes the list of build targets from static to dynamic based on the `supportedTargets` data from the existing `node-abi` dependency.

The current Node ABI is always built, as is Electron if it matches the Node ABI, which is the same as the existing logic. Rather than a hard-coded list, it now calculates the "oddball" Electron ABIs ("oddball" here meaning there is no corresponding version of Node with a given ABI).

Only ABIs greater than or equal to the earliest LTS Node are considered. This removes the old, unsupported Electron 1.x releases.

Builds occur in series via a new dependency in the form of `run-series`. This PR also adds the `tape` test runner, to match the other prebuild modules, with a few unit tests for the extracted logic.