### PR TITLE
Build for napi runtime when node-addon-api and napi_versions found

### DIFF
--- a/build-targets.js
+++ b/build-targets.js
@@ -23,7 +23,7 @@ function buildTargets (currentNode, supportedTargets, pkg) {
     .filter(target => !nodeAbis.includes(target.abi))
     .map(cleanTarget)
 
-  // N-API, requires node-addon-api and napi_versions
+  // N-API versions, requires napi_versions to be set
   const napiTargets = []
   if (pkg.binary && pkg.binary.napi_versions) {
     pkg.binary.napi_versions.forEach(napiVersion => {

--- a/build-targets.js
+++ b/build-targets.js
@@ -1,39 +1,44 @@
-function buildTargets (currentNodeAbi, supportedTargets) {
+function cleanTarget ({ runtime, abi, target }) {
+  return { runtime, abi, target }
+}
+
+function buildTargets (currentNode, supportedTargets, pkg) {
+  const nodeTarget = {
+    runtime: 'node',
+    abi: currentNode.modules,
+    target: currentNode.node
+  }
+
+  // Electron versions with the same ABI as current Node ABI
+  const electronTargets = supportedTargets
+    .filter(target => target.runtime === 'electron' && target.abi === currentNode.modules)
+    .map(cleanTarget)
+
+  // Oddball Electron versions, where no version of Node has the same ABI
   const nodeAbis = supportedTargets
     .filter(target => target.runtime === 'node')
     .map(target => target.abi)
+  const oddballElectronTargets = supportedTargets
+    .filter(target => target.runtime === 'electron' && target.abi >= currentNode.modules && !nodeAbis.includes(target.abi))
+    .map(cleanTarget)
 
-  const electronAbis = supportedTargets
-    .filter(target => target.runtime === 'electron')
-    .map(target => target.abi)
-
-  const oddballElectronAbis = electronAbis.filter(
-    electronAbi =>
-      electronAbi >= currentNodeAbi && !nodeAbis.includes(electronAbi)
-  )
-
-  // Current Node ABI
-  const targets = [
-    {
-      runtime: 'node',
-      abi: currentNodeAbi
-    }
-  ]
-  // Electron with same ABI as current Node
-  if (electronAbis.includes(currentNodeAbi)) {
-    targets.push({
-      runtime: 'electron',
-      abi: currentNodeAbi
+  // N-API, requires node-addon-api and napi_versions
+  const napiTargets = []
+  if (pkg.binary && pkg.binary.napi_versions) {
+    pkg.binary.napi_versions.forEach(napiVersion => {
+      napiTargets.push({
+        runtime: 'napi',
+        target: String(napiVersion)
+      })
     })
   }
-  // Oddball Electron ABIs
-  oddballElectronAbis.forEach(oddballAbi => {
-    targets.push({
-      runtime: 'electron',
-      abi: oddballAbi
-    })
-  })
-  return targets
+
+  return [
+    nodeTarget,
+    ...electronTargets,
+    ...oddballElectronTargets,
+    ...napiTargets
+  ]
 }
 
 module.exports = buildTargets

--- a/build-targets.js
+++ b/build-targets.js
@@ -19,7 +19,8 @@ function buildTargets (currentNode, supportedTargets, pkg) {
     .filter(target => target.runtime === 'node')
     .map(target => target.abi)
   const oddballElectronTargets = supportedTargets
-    .filter(target => target.runtime === 'electron' && target.abi >= currentNode.modules && !nodeAbis.includes(target.abi))
+    .filter(target => target.runtime === 'electron' && target.abi >= currentNode.modules)
+    .filter(target => !nodeAbis.includes(target.abi))
     .map(cleanTarget)
 
   // N-API, requires node-addon-api and napi_versions

--- a/index.js
+++ b/index.js
@@ -8,6 +8,8 @@ const version = require('./package').version
 const runSeries = require('run-series')
 const supportedTargets = require('node-abi').supportedTargets
 const buildTargets = require('./build-targets')
+const path = require('path')
+const pkg = require(path.resolve('package.json'))
 
 if (!process.env.CI) process.exit()
 
@@ -47,10 +49,10 @@ versionChanged(function (err, changed) {
     process.exit(0)
   }
 
-  const builds = buildTargets(process.versions.modules, supportedTargets)
+  const builds = buildTargets(process.versions, supportedTargets, pkg)
     .map(function (target) {
       return function (cb) {
-        prebuild(target.runtime, target.abi, cb)
+        prebuild(target.runtime, target.target, cb)
       }
     })
 

--- a/test/build-targets-test.js
+++ b/test/build-targets-test.js
@@ -26,43 +26,70 @@ const supportedTargets = [
 
 test('build targets using Node 6 (ABI 48)', function (t) {
   t.plan(1)
-  const targets = buildTargets('48', supportedTargets)
+  const targets = buildTargets({ node: '6.0.0', modules: '48' }, supportedTargets, {})
   t.deepEqual(targets, [
-    { runtime: 'node', abi: '48' },
-    { runtime: 'electron', abi: '48' },
-    { runtime: 'electron', abi: '49' },
-    { runtime: 'electron', abi: '50' },
-    { runtime: 'electron', abi: '53' },
-    { runtime: 'electron', abi: '54' },
-    { runtime: 'electron', abi: '69' }
+    { runtime: 'node', abi: '48', target: '6.0.0' },
+    { runtime: 'electron', abi: '48', target: '1.1.0' },
+    { runtime: 'electron', abi: '49', target: '1.3.0' },
+    { runtime: 'electron', abi: '50', target: '1.4.0' },
+    { runtime: 'electron', abi: '53', target: '1.6.0' },
+    { runtime: 'electron', abi: '54', target: '1.7.0' },
+    { runtime: 'electron', abi: '69', target: '4.0.4' }
   ])
 })
 
 test('build targets using Node 8 (ABI 57)', function (t) {
   t.plan(1)
-  const targets = buildTargets('57', supportedTargets)
+  const targets = buildTargets({ node: '8.0.0', modules: '57' }, supportedTargets, {})
   t.deepEqual(targets, [
-    { runtime: 'node', abi: '57' },
-    { runtime: 'electron', abi: '57' },
-    { runtime: 'electron', abi: '69' }
+    { runtime: 'node', abi: '57', target: '8.0.0' },
+    { runtime: 'electron', abi: '57', target: '1.8.0' },
+    { runtime: 'electron', abi: '57', target: '2.0.0' },
+    { runtime: 'electron', abi: '69', target: '4.0.4' }
   ])
 })
 
 test('build targets using Node 10 (ABI 64)', function (t) {
   t.plan(1)
-  const targets = buildTargets('64', supportedTargets)
+  const targets = buildTargets({ node: '10.0.0', modules: '64' }, supportedTargets, {})
   t.deepEqual(targets, [
-    { runtime: 'node', abi: '64' },
-    { runtime: 'electron', abi: '64' },
-    { runtime: 'electron', abi: '69' }
+    { runtime: 'node', abi: '64', target: '10.0.0' },
+    { runtime: 'electron', abi: '64', target: '3.0.0' },
+    { runtime: 'electron', abi: '64', target: '4.0.0' },
+    { runtime: 'electron', abi: '69', target: '4.0.4' }
   ])
 })
 
 test('build targets using Node 11 (ABI 67)', function (t) {
   t.plan(1)
-  const targets = buildTargets('67', supportedTargets)
+  const targets = buildTargets({ node: '11.0.0', modules: '67' }, supportedTargets, {})
   t.deepEqual(targets, [
-    { runtime: 'node', abi: '67' },
-    { runtime: 'electron', abi: '69' }
+    { runtime: 'node', abi: '67', target: '11.0.0' },
+    { runtime: 'electron', abi: '69', target: '4.0.4' }
+  ])
+})
+
+test('build targets using Node 12 (ABI 72)', function (t) {
+  t.plan(1)
+  const targets = buildTargets({ node: '12.0.0', modules: '72' }, supportedTargets, {})
+  t.deepEqual(targets, [
+    { runtime: 'node', abi: '72', target: '12.0.0' }
+  ])
+})
+
+test('build napi targets when napi_versions found', function (t) {
+  t.plan(1)
+  const targets = buildTargets({ node: '10.0.0', modules: '64' }, supportedTargets, {
+    binary: {
+      napi_versions: [3, 4]
+    }
+  })
+  t.deepEqual(targets, [
+    { runtime: 'node', abi: '64', target: '10.0.0' },
+    { runtime: 'electron', abi: '64', target: '3.0.0' },
+    { runtime: 'electron', abi: '64', target: '4.0.0' },
+    { runtime: 'electron', abi: '69', target: '4.0.4' },
+    { runtime: 'napi', target: '3' },
+    { runtime: 'napi', target: '4' }
   ])
 })


### PR DESCRIPTION
Once a native module has made the leap to using N-API via [node-addon-api](https://github.com/nodejs/node-addon-api), attempting to build for node and electron ABI runtimes will fail.

This is, in part, due to a lack of a one-to-one mapping between node/electron ABIs and napi ABIs e.g. node ABI 57 maps to napi ABI 1, 2, 3 and 4.

This change is fully backwards compatible. Existing modules that do not both depend on `node-addon-api` and specify [napi_versions](https://github.com/prebuild/prebuild#declaring-supported-n-api-versions) carry on as before.